### PR TITLE
Use Corretto 17 (LTS) for Settlement Service

### DIFF
--- a/lib/services/settlement/app/Dockerfile
+++ b/lib/services/settlement/app/Dockerfile
@@ -7,7 +7,7 @@ RUN \
     curl -s "https://get.sdkman.io" | bash; \
     bash -c "source $HOME/.sdkman/bin/sdkman-init.sh; \
     sdk install maven; \
-    sdk install java 19.0.2-amzn;"
+    sdk install java 17.0.8-amzn;"
 
 COPY ./pom.xml ./pom.xml
 COPY src ./src/


### PR DESCRIPTION
*Issue #, if available:* #31

*Description of changes:* Corretto 19 expired in April 2023, resulting in an error when running `cdk deploy`.  Update Dockerfile for Settlement Service to use Corretto 17 (LTS).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
